### PR TITLE
BaseEntity new Auditable columns

### DIFF
--- a/src/SpotLights.Data/Data/ApplicationDbContext.cs
+++ b/src/SpotLights.Data/Data/ApplicationDbContext.cs
@@ -28,50 +28,50 @@ internal class ApplicationDbContext : IdentityUserContext<UserInfo, int>
     {
         base.OnModelCreating(modelBuilder);
 
-        _ = modelBuilder.Entity<UserInfo>(e =>
+        modelBuilder.Entity<UserInfo>(e =>
         {
-            _ = e.ToTable("Users");
-            _ = e.Property(p => p.Id).HasMaxLength(128);
-            _ = e.Property(p => p.CreatedAt).HasColumnOrder(0);
-            _ = e.Property(p => p.UpdatedAt).HasColumnOrder(1);
-            _ = e.Property(p => p.PasswordHash).HasMaxLength(256);
-            _ = e.Property(p => p.SecurityStamp).HasMaxLength(32);
-            _ = e.Property(p => p.ConcurrencyStamp).HasMaxLength(64);
-            _ = e.Property(p => p.PhoneNumber).HasMaxLength(32);
+            e.ToTable("Users");
+            e.Property(p => p.Id).HasMaxLength(128);
+            e.Property(p => p.CreatedAt).HasColumnOrder(0);
+            e.Property(p => p.UpdatedAt).HasColumnOrder(1);
+            e.Property(p => p.PasswordHash).HasMaxLength(256);
+            e.Property(p => p.SecurityStamp).HasMaxLength(32);
+            e.Property(p => p.ConcurrencyStamp).HasMaxLength(64);
+            e.Property(p => p.PhoneNumber).HasMaxLength(32);
         });
 
-        _ = modelBuilder.Entity<IdentityUserClaim<int>>(e =>
+        modelBuilder.Entity<IdentityUserClaim<int>>(e =>
         {
-            _ = e.ToTable("UserClaim");
-            _ = e.Property(p => p.ClaimType).HasMaxLength(16);
-            _ = e.Property(p => p.ClaimValue).HasMaxLength(256);
+            e.ToTable("UserClaim");
+            e.Property(p => p.ClaimType).HasMaxLength(16);
+            e.Property(p => p.ClaimValue).HasMaxLength(256);
         });
-        _ = modelBuilder.Entity<IdentityUserLogin<int>>(e =>
+        modelBuilder.Entity<IdentityUserLogin<int>>(e =>
         {
-            _ = e.ToTable("UserLogin");
-            _ = e.Property(p => p.ProviderDisplayName).HasMaxLength(128);
+            e.ToTable("UserLogin");
+            e.Property(p => p.ProviderDisplayName).HasMaxLength(128);
         });
-        _ = modelBuilder.Entity<IdentityUserToken<int>>(e =>
+        modelBuilder.Entity<IdentityUserToken<int>>(e =>
         {
-            _ = e.ToTable("UserToken");
-            _ = e.Property(p => p.Value).HasMaxLength(1024);
-        });
-
-        _ = modelBuilder.Entity<OptionInfo>(e =>
-        {
-            _ = e.ToTable("Options");
-            _ = e.HasIndex(b => b.Key).IsUnique();
+            e.ToTable("UserToken");
+            e.Property(p => p.Value).HasMaxLength(1024);
         });
 
-        _ = modelBuilder.Entity<Post>(e =>
+        modelBuilder.Entity<OptionInfo>(e =>
         {
-            _ = e.ToTable("Posts");
-            _ = e.HasIndex(b => b.Slug).IsUnique();
+            e.ToTable("Options");
+            e.HasIndex(b => b.Key).IsUnique();
         });
 
-        _ = modelBuilder.Entity<Storage>(e =>
+        modelBuilder.Entity<Post>(e =>
         {
-            _ = e.ToTable("Storages");
+            e.ToTable("Posts");
+            e.HasIndex(b => b.Slug).IsUnique();
+        });
+
+        modelBuilder.Entity<Storage>(e =>
+        {
+            e.ToTable("Storages");
         });
 
         //modelBuilder.Entity<StorageReference>(e =>
@@ -80,10 +80,10 @@ internal class ApplicationDbContext : IdentityUserContext<UserInfo, int>
         //  e.HasKey(t => new { t.StorageId, t.EntityId });
         //});
 
-        _ = modelBuilder.Entity<PostCategory>(e =>
+        modelBuilder.Entity<PostCategory>(e =>
         {
-            _ = e.ToTable("PostCategories");
-            _ = e.HasKey(t => new { t.PostId, t.CategoryId });
+            e.ToTable("PostCategories");
+            e.HasKey(t => new { t.PostId, t.CategoryId });
         });
     }
 }

--- a/src/SpotLights.Data/GlobalUsings.cs
+++ b/src/SpotLights.Data/GlobalUsings.cs
@@ -1,2 +1,0 @@
-//global using DefaultIdType = global::System.Guid; // Primary key type Guid
-global using DefaultIdType = global::System.Int32; // Primary key type Integer

--- a/src/SpotLights.Data/Migrations/SqlServer/20240520125009_Category_add_col_ShowInMenu.Designer.cs
+++ b/src/SpotLights.Data/Migrations/SqlServer/20240520125009_Category_add_col_ShowInMenu.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SpotLights.Data;
 
@@ -11,9 +12,11 @@ using SpotLights.Data;
 namespace SpotLights.Data.Migrations.SqlServer
 {
     [DbContext(typeof(SqlServerDbContext))]
-    partial class SqlServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240520125009_Category_add_col_ShowInMenu")]
+    partial class Category_add_col_ShowInMenu
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -154,11 +157,6 @@ namespace SpotLights.Data.Migrations.SqlServer
                         .HasColumnOrder(0)
                         .HasDefaultValueSql("getdate()");
 
-                    b.Property<string>("CreatedBy")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
                     b.Property<string>("Email")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
@@ -169,9 +167,6 @@ namespace SpotLights.Data.Migrations.SqlServer
                     b.Property<string>("Gender")
                         .HasMaxLength(32)
                         .HasColumnType("nvarchar(32)");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
 
                     b.Property<bool>("LockoutEnabled")
                         .HasColumnType("bit");
@@ -250,21 +245,13 @@ namespace SpotLights.Data.Migrations.SqlServer
                         .HasColumnType("datetime2")
                         .HasDefaultValueSql("getdate()");
 
-                    b.Property<string>("CreatedBy")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
-
                     b.Property<int>("PostId")
                         .HasColumnType("int");
 
                     b.Property<bool>("Success")
                         .HasColumnType("bit");
 
-                    b.Property<DateTime?>("UpdatedAt")
+                    b.Property<DateTime>("UpdatedAt")
                         .HasColumnType("datetime2");
 
                     b.HasKey("Id");
@@ -291,11 +278,6 @@ namespace SpotLights.Data.Migrations.SqlServer
                         .HasColumnType("datetime2")
                         .HasDefaultValueSql("getdate()");
 
-                    b.Property<string>("CreatedBy")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
                     b.Property<string>("Email")
                         .IsRequired()
                         .HasMaxLength(160)
@@ -305,14 +287,11 @@ namespace SpotLights.Data.Migrations.SqlServer
                         .HasMaxLength(80)
                         .HasColumnType("nvarchar(80)");
 
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
-
                     b.Property<string>("Region")
                         .HasMaxLength(120)
                         .HasColumnType("nvarchar(120)");
 
-                    b.Property<DateTime?>("UpdatedAt")
+                    b.Property<DateTime>("UpdatedAt")
                         .HasColumnType("datetime2");
 
                     b.HasKey("Id");
@@ -338,23 +317,12 @@ namespace SpotLights.Data.Migrations.SqlServer
                         .HasColumnType("datetime2")
                         .HasDefaultValueSql("getdate()");
 
-                    b.Property<string>("CreatedBy")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
                     b.Property<string>("Description")
                         .HasMaxLength(255)
                         .HasColumnType("nvarchar(255)");
 
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
-
                     b.Property<bool>("ShowInMenu")
                         .HasColumnType("bit");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
 
                     b.HasKey("Id");
 
@@ -382,18 +350,10 @@ namespace SpotLights.Data.Migrations.SqlServer
                         .HasColumnType("datetime2")
                         .HasDefaultValueSql("getdate()");
 
-                    b.Property<string>("CreatedBy")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
                     b.Property<string>("Description")
                         .IsRequired()
                         .HasMaxLength(450)
                         .HasColumnType("nvarchar(450)");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
 
                     b.Property<int>("PostType")
                         .HasColumnType("int");
@@ -414,7 +374,7 @@ namespace SpotLights.Data.Migrations.SqlServer
                         .HasMaxLength(160)
                         .HasColumnType("nvarchar(160)");
 
-                    b.Property<DateTime?>("UpdatedAt")
+                    b.Property<DateTime>("UpdatedAt")
                         .HasColumnType("datetime2");
 
                     b.Property<int>("UserId")
@@ -466,10 +426,8 @@ namespace SpotLights.Data.Migrations.SqlServer
                         .HasColumnType("datetime2")
                         .HasDefaultValueSql("getdate()");
 
-                    b.Property<string>("CreatedBy")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
@@ -494,9 +452,6 @@ namespace SpotLights.Data.Migrations.SqlServer
 
                     b.Property<int>("Type")
                         .HasColumnType("int");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
 
                     b.Property<DateTime>("UploadAt")
                         .HasColumnType("datetime2");

--- a/src/SpotLights.Data/Migrations/SqlServer/20240520125009_Category_add_col_ShowInMenu.cs
+++ b/src/SpotLights.Data/Migrations/SqlServer/20240520125009_Category_add_col_ShowInMenu.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SpotLights.Data.Migrations.SqlServer
+{
+    /// <inheritdoc />
+    public partial class Category_add_col_ShowInMenu : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Storages",
+                type: "nvarchar(1024)",
+                maxLength: 1024,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UploadAt",
+                table: "Storages",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowInMenu",
+                table: "Categories",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UploadAt",
+                table: "Storages");
+
+            migrationBuilder.DropColumn(
+                name: "ShowInMenu",
+                table: "Categories");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Storages",
+                type: "nvarchar(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1024)",
+                oldMaxLength: 1024);
+        }
+    }
+}

--- a/src/SpotLights.Data/Migrations/SqlServer/20240520132015_Add_BaseEntity_Cols_For_All_Table.Designer.cs
+++ b/src/SpotLights.Data/Migrations/SqlServer/20240520132015_Add_BaseEntity_Cols_For_All_Table.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SpotLights.Data;
 
@@ -11,9 +12,11 @@ using SpotLights.Data;
 namespace SpotLights.Data.Migrations.SqlServer
 {
     [DbContext(typeof(SqlServerDbContext))]
-    partial class SqlServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240520132015_Add_BaseEntity_Cols_For_All_Table")]
+    partial class Add_BaseEntity_Cols_For_All_Table
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/SpotLights.Data/Migrations/SqlServer/20240520132015_Add_BaseEntity_Cols_For_All_Table.cs
+++ b/src/SpotLights.Data/Migrations/SqlServer/20240520132015_Add_BaseEntity_Cols_For_All_Table.cs
@@ -1,0 +1,220 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SpotLights.Data.Migrations.SqlServer
+{
+    /// <inheritdoc />
+    public partial class Add_BaseEntity_Cols_For_All_Table : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "DeletedAt",
+                table: "Storages",
+                newName: "UpdatedAt");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Users",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Users",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Subscribers",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Subscribers",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Subscribers",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Storages",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Posts",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Posts",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Posts",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Newsletters",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Newsletters",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Newsletters",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Categories",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Categories",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Categories",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Subscribers");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Subscribers");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Storages");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Posts");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Posts");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Newsletters");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Newsletters");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Categories");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Categories");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                table: "Categories");
+
+            migrationBuilder.RenameColumn(
+                name: "UpdatedAt",
+                table: "Storages",
+                newName: "DeletedAt");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Subscribers",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Posts",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "Newsletters",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/SpotLights.Data/SpotLights.Data.csproj
+++ b/src/SpotLights.Data/SpotLights.Data.csproj
@@ -20,6 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.4" />

--- a/src/SpotLights.Domain/Base/BaseEntity.cs
+++ b/src/SpotLights.Domain/Base/BaseEntity.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace SpotLights.Domain.Base;
 
 public abstract class BaseEntity : BaseEntity<DefaultIdType>
@@ -8,4 +10,14 @@ public abstract class BaseEntity : BaseEntity<DefaultIdType>
 public abstract class BaseEntity<TId> : IEntity<TId>
 {
     public TId Id { get; set; } = default!;
+
+    public DateTime CreatedAt { get; set; } = DateTime.Now;
+
+    public DateTime? UpdatedAt { get; set; }
+
+    [StringLength(128)]
+    public string CreatedBy { get; set; } = default!;
+
+    // For soft delete
+    public bool IsDeleted { get; set; }
 }

--- a/src/SpotLights.Domain/Model/Identity/UserInfo.cs
+++ b/src/SpotLights.Domain/Model/Identity/UserInfo.cs
@@ -16,9 +16,6 @@ public class UserInfo : IdentityUser<DefaultIdType>
         UserName = userName;
     }
 
-    public DateTime CreatedAt { get; set; }
-    public DateTime UpdatedAt { get; set; }
-
     [StringLength(256)]
     public string NickName { get; set; } = default!;
 
@@ -33,4 +30,13 @@ public class UserInfo : IdentityUser<DefaultIdType>
 
     public UserType Type { get; set; }
     public UserState State { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    [StringLength(128)]
+    public string CreatedBy { get; set; } = default!;
+
+    // For soft delete
+    public bool IsDeleted { get; set; }
 }

--- a/src/SpotLights.Domain/Model/Newsletters/Newsletter.cs
+++ b/src/SpotLights.Domain/Model/Newsletters/Newsletter.cs
@@ -1,13 +1,10 @@
 using SpotLights.Domain.Base;
 using SpotLights.Domain.Model.Posts;
-using System;
 
 namespace SpotLights.Domain.Model.Newsletters;
 
 public class Newsletter : BaseEntity
 {
-    public DateTime CreatedAt { get; set; }
-    public DateTime UpdatedAt { get; set; }
     public int PostId { get; set; }
     public bool Success { get; set; }
     public Post Post { get; set; } = default!;

--- a/src/SpotLights.Domain/Model/Newsletters/Subscriber.cs
+++ b/src/SpotLights.Domain/Model/Newsletters/Subscriber.cs
@@ -6,9 +6,6 @@ namespace SpotLights.Domain.Model.Newsletters;
 
 public class Subscriber : BaseEntity
 {
-    public DateTime CreatedAt { get; set; }
-    public DateTime UpdatedAt { get; set; }
-
     [EmailAddress]
     [StringLength(160)]
     public string Email { get; set; } = default!;

--- a/src/SpotLights.Domain/Model/Posts/Category.cs
+++ b/src/SpotLights.Domain/Model/Posts/Category.cs
@@ -5,12 +5,12 @@ namespace SpotLights.Domain.Model.Posts;
 
 public class Category : BaseEntity
 {
-    public DateTime CreatedAt { get; set; }
-
     [StringLength(120)]
     public string Content { get; set; } = default!;
 
     [StringLength(255)]
     public string? Description { get; set; } = default!;
     public List<PostCategory>? PostCategories { get; set; }
+
+    public bool ShowInMenu { get; set; }
 }

--- a/src/SpotLights.Domain/Model/Posts/Post.cs
+++ b/src/SpotLights.Domain/Model/Posts/Post.cs
@@ -7,8 +7,6 @@ namespace SpotLights.Domain.Model.Posts;
 
 public class Post : BaseEntity
 {
-    public DateTime CreatedAt { get; set; }
-    public DateTime UpdatedAt { get; set; }
     public DefaultIdType UserId { get; set; }
     public UserInfo User { get; set; } = default!;
 

--- a/src/SpotLights.Domain/Model/Storage/Storage.cs
+++ b/src/SpotLights.Domain/Model/Storage/Storage.cs
@@ -9,8 +9,6 @@ public class Storage : BaseEntity
 {
     public DefaultIdType UserId { get; set; }
     public UserInfo User { get; set; } = default!;
-    public DateTime CreatedAt { get; set; }
-    public DateTime UploadAt { get; set; }
 
     [StringLength(2048)]
     public string Slug { get; set; } = default!;
@@ -27,5 +25,8 @@ public class Storage : BaseEntity
     public string ContentType { get; set; } = default!;
 
     public StorageType Type { get; set; }
+
     //public List<StorageReference>? StorageReferences { get; set; }
+
+    public DateTime UploadAt { get; set; }
 }

--- a/src/SpotLights.Infrastructure/Interfaces/Posts/IPostRepository.cs
+++ b/src/SpotLights.Infrastructure/Interfaces/Posts/IPostRepository.cs
@@ -9,9 +9,9 @@ namespace SpotLights.Infrastructure.Interfaces.Posts
     {
         Task<IEnumerable<PostEditorDto>> AddAsync(IEnumerable<PostEditorDto> posts, int userId);
         Task<string> AddAsync(PostEditorDto postInput, int userId);
-        Task<PostDto> FirstAsync(int id);
+        Task<PostDto> FirstAsync(DefaultIdType id);
         Task<IEnumerable<PostDto>> GetAsync();
-        Task<PostDto> GetAsync(int id);
+        Task<PostDto> GetAsync(DefaultIdType id);
         Task<IEnumerable<PostItemDto>> GetAsync(
             PublishedStatus filter,
             PostType postType,

--- a/src/SpotLights.Infrastructure/Manager/Storages/StorageLocalProvider.cs
+++ b/src/SpotLights.Infrastructure/Manager/Storages/StorageLocalProvider.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using SpotLights.Data.Data;
+using SpotLights.Domain.Model.Newsletters;
 using SpotLights.Domain.Model.Storage;
 using SpotLights.Infrastructure.Interfaces;
 using SpotLights.Infrastructure.Interfaces.Storages;
@@ -87,6 +88,7 @@ internal class StorageLocalProvider : BaseContextRepository, IStorageMinioProvid
                 Type = StorageType.Local
             };
         await AddAsync(storage);
+
         return storage.Adapt<StorageDto>();
     }
 

--- a/src/SpotLights.Shared/Entities/Identity/UserType.cs
+++ b/src/SpotLights.Shared/Entities/Identity/UserType.cs
@@ -3,5 +3,6 @@ namespace SpotLights.Shared.Entities.Identity;
 public enum UserType
 {
     Ordinary = 0,
+    Basic = 1,
     Administrator = 1000,
 }

--- a/src/SpotLights/Api/BlogController.cs
+++ b/src/SpotLights/Api/BlogController.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Mapster;
 using SpotLights.Infrastructure.Repositories.Blogs;
 using SpotLights.Core.Interfaces;
+using SpotLights.Core.Services.Blogs;
 
 namespace SpotLights.Interfaces;
 

--- a/src/SpotLights/SpotLights.csproj
+++ b/src/SpotLights/SpotLights.csproj
@@ -13,7 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.4" />
-
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
 
   </ItemGroup>
 


### PR DESCRIPTION
Added default Base auditable columns for all tables

    public DateTime CreatedAt { get; set; } = DateTime.Now;

    public DateTime? UpdatedAt { get; set; }

    [StringLength(128)]
    public string CreatedBy { get; set; } = default!;

    // For soft delete
    public bool IsDeleted { get; set; }